### PR TITLE
Feature/symfony 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "require": {
         "php": ">=5.3.2",
         "doctrine/mongodb": "1.*",
-        "symfony/console": "2.*|^3.0",
-        "symfony/yaml": "2.*|^3.0"
+        "symfony/console": "^2.5|^3.0",
+        "symfony/yaml": "^2.5|^3.0"
     },
     "require-dev": {
         "antimattr/test-case": "~1.0@stable",
         "phpunit/phpunit": "~4.0",
-        "fabpot/php-cs-fixer": "0.5.*@dev",
+        "friendsofphp/php-cs-fixer": "^1.0",
         "mikey179/vfsStream": "1.*"
     },
     "minimum-stability": "dev",

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/YamlConfiguration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/YamlConfiguration.php
@@ -19,11 +19,11 @@ use Symfony\Component\Yaml\Yaml;
 class YamlConfiguration extends AbstractFileConfiguration
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected function doLoad($file)
     {
-        $array = Yaml::parse($file);
+        $array = Yaml::parse(file_get_contents($file));
 
         if (isset($array['name'])) {
             $this->setName($array['name']);

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/ExecuteCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -66,7 +67,15 @@ EOT
         if (!$input->isInteractive()) {
             $version->execute($direction);
         } else {
-            $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);
+            $question = new ConfirmationQuestion(
+                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question> ',
+                'n'
+            );
+
+            $confirmation = $this
+                ->getHelper('question')
+                ->ask($input, $output, $question);
+
             if ($confirmation === true) {
                 $version->execute($direction);
             } else {

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/MigrateCommand.php
@@ -16,6 +16,7 @@ use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
@@ -81,8 +82,16 @@ EOT
             }
 
             if (! $noInteraction) {
-                $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>Are you sure you wish to continue? (y/n)</question>', false);
-                if (! $confirmation) {
+                $question = new ConfirmationQuestion(
+                    '<question>Are you sure you wish to continue? (y/n)</question> ',
+                    'n'
+                );
+
+                $confirmation = $this
+                    ->getHelper('question')
+                    ->ask($input, $output, $question);
+
+                if (!$confirmation) {
                     $output->writeln('<error>Migration cancelled!</error>');
 
                     return 1;
@@ -92,7 +101,15 @@ EOT
 
         // warn the user if no dry run and interaction is on
         if (! $noInteraction) {
-            $confirmation = $this->getHelper('dialog')->askConfirmation($output, '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question>', false);
+            $question = new ConfirmationQuestion(
+                '<question>WARNING! You are about to execute a database migration that could result in data lost. Are you sure you wish to continue? (y/n)</question> ',
+                'n'
+            );
+
+            $confirmation = $this
+                ->getHelper('question')
+                ->ask($input, $output, $question);
+
             if (! $confirmation) {
                 $output->writeln('<error>Migration cancelled!</error>');
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/ExecuteCommandTest.php
@@ -39,7 +39,7 @@ class ExecuteCommandTest extends AntiMattrTestCase
                 'application-name',
                 ExecuteCommand::NAME,
                 $numVersion,
-                '--down'
+                '--down',
             )
         );
 
@@ -78,7 +78,7 @@ class ExecuteCommandTest extends AntiMattrTestCase
         $application = new Application();
         $helperSet = new HelperSet(
             array(
-                'question' => $question
+                'question' => $question,
             )
         );
         $numVersion = '1234567890';
@@ -89,7 +89,7 @@ class ExecuteCommandTest extends AntiMattrTestCase
             array(
                 'application-name',
                 ExecuteCommand::NAME,
-                $numVersion
+                $numVersion,
             )
         );
 
@@ -109,7 +109,7 @@ class ExecuteCommandTest extends AntiMattrTestCase
         ;
 
         $question->expects($this->once())
-            ->method('askConfirmation')
+            ->method('ask')
             ->will(
                 $this->returnValue(true)
             )

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/ExecuteCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/ExecuteCommandTest.php
@@ -72,13 +72,13 @@ class ExecuteCommandTest extends AntiMattrTestCase
     public function testExecuteUpWithInteraction()
     {
         // Mocks
-        $dialog = $this->buildMock('Symfony\Component\Console\Helper\DialogHelper');
+        $question = $this->buildMock('Symfony\Component\Console\Helper\QuestionHelper');
 
         // Variables and Objects
         $application = new Application();
         $helperSet = new HelperSet(
             array(
-                'dialog' => $dialog
+                'question' => $question
             )
         );
         $numVersion = '1234567890';
@@ -108,7 +108,7 @@ class ExecuteCommandTest extends AntiMattrTestCase
             )
         ;
 
-        $dialog->expects($this->once())
+        $question->expects($this->once())
             ->method('askConfirmation')
             ->will(
                 $this->returnValue(true)

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
@@ -36,7 +36,7 @@ class MigrateCommandTest extends AntiMattrTestCase
             array(
                 'application-name',
                 MigrateCommand::NAME,
-                $numVersion
+                $numVersion,
             )
         );
         $interactive = true;
@@ -45,7 +45,7 @@ class MigrateCommandTest extends AntiMattrTestCase
         $application = new Application();
         $helperSet = new HelperSet(
             array(
-                'question' => $question
+                'question' => $question,
             )
         );
 
@@ -72,7 +72,7 @@ class MigrateCommandTest extends AntiMattrTestCase
         ;
 
         $question->expects($this->exactly(2))
-            ->method('askConfirmation')
+            ->method('ask')
             ->will(
                 $this->returnValue(true)
             )
@@ -102,7 +102,7 @@ class MigrateCommandTest extends AntiMattrTestCase
         $input = new ArgvInput(
             array(
                 MigrateCommand::NAME,
-                $numVersion
+                $numVersion,
             )
         );
         $interactive = false;

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
@@ -28,7 +28,7 @@ class MigrateCommandTest extends AntiMattrTestCase
         $configuration = $this->buildMock('AntiMattr\MongoDB\Migrations\Configuration\Configuration');
         $executedVersion = $this->buildMock('AntiMattr\MongoDB\Migrations\Version');
         $migration = $this->buildMock('AntiMattr\MongoDB\Migrations\Migration');
-        $dialog = $this->buildMock('Symfony\Component\Console\Helper\DialogHelper');
+        $question = $this->buildMock('Symfony\Component\Console\Helper\QuestionHelper');
 
         // Variables and Objects
         $numVersion = '000123456789';
@@ -45,7 +45,7 @@ class MigrateCommandTest extends AntiMattrTestCase
         $application = new Application();
         $helperSet = new HelperSet(
             array(
-                'dialog' => $dialog
+                'question' => $question
             )
         );
 
@@ -71,7 +71,7 @@ class MigrateCommandTest extends AntiMattrTestCase
             )
         ;
 
-        $dialog->expects($this->exactly(2))
+        $question->expects($this->exactly(2))
             ->method('askConfirmation')
             ->will(
                 $this->returnValue(true)


### PR DESCRIPTION
The DialogHelper was removed in symfony 3. The QuestionHelper is available from 2.5.

The other changes were to fix up the unit tests.